### PR TITLE
edit 「github 動態」 url

### DIFF
--- a/app/partials/nav.jade
+++ b/app/partials/nav.jade
@@ -61,7 +61,7 @@ ul.nav
       li(role='presentation') 
         a(target="_blank" role='menuitem', tabindex='-1',ng-href='/project') 專案列表
       li(role='presentation')
-        a(target="_blank" href='https://github.com/orgs/g0v/dashboard') github 動態
+        a(target="_blank" href='https://github.com/g0v') github 動態
       li(role='presentation')
         a(target="_blank" href='https://g0v.hackpad.com/') hackpad 共筆動態
       li(role='presentation')


### PR DESCRIPTION
舊的 url: https://github.com/orgs/g0v/dashboard 會 redirect 回 github.com ((也許是因為非 org members
改成 https://github.com/g0v
