### PR TITLE
Fix navbar dropdowns

### DIFF
--- a/app/partials/nav.jade
+++ b/app/partials/nav.jade
@@ -2,10 +2,10 @@ ul.nav
   li
     a(ng-href='/') 揪松網
   li.dropdown-split-right.dropdown
-    a.dropdown-toggle
+    button.btn-link.dropdown-toggle(type='button', aria-haspopup='true')
       | 各期黑客松共筆
-      i.icon-caret-down
-    ul.dropdown-menu.pull-right(role='menu', aria-labelledby='projects')
+      i.icon-caret-down(aria-hidden='true')
+    ul.dropdown-menu.pull-right(role='menu')
       li
         a(ng-href='/g0v-hackath19n') 飛彈試射/20160618
       li
@@ -19,10 +19,10 @@ ul.nav
       li
         a(target='_blank' href='https://www.google.com/calendar/embed?src=cpcf6iv5pt9l6gl2ue3svo63e8%40group.calendar.google.com&ctz=Asia/Taipei') 社群行事曆
   //li.dropdown
-    a.dropdown-toggle
+    button.btn-link.dropdown-toggle(type='button', aria-haspopup='true')
       | 長期專案
-      i.icon-caret-down
-    ul.dropdown-menu.pull-right(role='menu', aria-labelledby='projects')
+      i.icon-caret-down(aria-hidden='true')
+    ul.dropdown-menu.pull-right(role='menu')
       li(role='presentation')
         a(role='menuitem', tabindex='-1',ng-href='/projectpool') g0v專案池
       li(role='presentation')
@@ -44,10 +44,10 @@ ul.nav
       li(role='presentation')
         a(role='menuitem', tabindex='-1',ng-href='/g0v-summit2014') 2014 summit
   li.dropdown
-    a.dropdown-toggle
+    button.btn-link.dropdown-toggle(type='button', aria-haspopup='true')
       | 協作平台
-      i.icon-caret-down
-    ul.dropdown-menu.pull-right(role='menu', aria-labelledby='projects')
+      i.icon-caret-down(aria-hidden='true')
+    ul.dropdown-menu.pull-right(role='menu')(role='menu', aria-labelledby='projects')
       li(role='presentation')
         a(target="_blank" role='menuitem', tabindex='-1',ng-href='/project') 專案列表
       li(role='presentation')
@@ -57,10 +57,10 @@ ul.nav
       li(role='presentation')
         a(target="_blank" href='https://drive.google.com/folderview?id=0B0NsS2a-Qx8ZN19uV1p6YWd6TXc#') g0v google drive
    li.dropdown
-    a.dropdown-toggle
+    button.btn-link.dropdown-toggle(type='button', aria-haspopup='true')
       | 討論
-      i.icon-caret-down
-    ul.dropdown-menu.pull-right(role='menu', aria-labelledby='projects')
+      i.icon-caret-down(aria-hidden='true')
+    ul.dropdown-menu.pull-right(role='menu')
       li(role='presentation')
         a(target="_blank" role='menuitem', tabindex='-1',ng-href='/irc') IRC 聊天室
       li(role='presentation')
@@ -72,11 +72,10 @@ ul.nav
       li(role='presentation')
         a(target="_blank" href='/mail-archive') 過往電子報
   li.dropdown
-    a.dropdown-toggle
+    button.btn-link.dropdown-toggle(type='button', aria-haspopup='true')
       | 資源
-      i.icon-caret-down
-    ul.dropdown-menu.pull-right(role='menu', aria-labelledby='projects')
-
+      i.icon-caret-down(aria-hidden='true')
+    ul.dropdown-menu.pull-right(role='menu')
       li(role='presentation')
         a(target="_blank" href='http://data.g0v.tw/') 資料集
       li(role='presentation')

--- a/app/styles/hack.styl
+++ b/app/styles/hack.styl
@@ -27,7 +27,17 @@ body
 .navbar-inverse .nav > li > a
   color #ccc!important
   text-shadow 0 0 1px rgba(255,255,255,0.3)
-.navbar-inverse .nav > li > a:hover
+.navbar-inverse .nav > li > .btn-link
+  color #ccc!important
+  font-size 16px
+  padding 8px 5px
+.navbar-inverse .icon-caret-down
+  margin-left 5px
+  vertical-align baseline
+.navbar-inverse .nav > li > a:hover,
+.navbar-inverse .nav > li > .btn-link:hover,
+.navbar-inverse .nav > li > .btn-link:focus
+  text-decoration none
   color #fff!important
   text-shadow 0 0px 16px rgba(128,128,128,1)
   background-color rgba(255,255,255,0.1)
@@ -36,7 +46,7 @@ body
   color hsl(0, 0%, 75%)
 .navbar-fixed-top .container
   width 945px
-  
+
 /* hide nav labels when window.width < 1200px */
 @media (max-width: 1200px)
   .navbar ul.nav span.label


### PR DESCRIPTION
- Use buttons for dropdown as they aren't "links", plus `<a>` without `href` isn't tabbable
- Add `aria-haspopup` to indicate dropdown
- `#projects` doesn't exist, `aria-labelledby` has no effect
- Caret isn't useful for sr's so should be hidden
- Fix caret position

:warning:  Would've added `aria-expanded` as well, but doesn't look like it's quite as easy to add a script to toggle the attribute :pensive:

Before

![](https://cl.ly/1g0P1o3N0r0p/Screen%20Recording%202016-12-15%20at%2002.02%20PM.gif)

After

![](https://cl.ly/0U0j0h1O0P31/Screen%20Recording%202016-12-15%20at%2002.02%20PM.gif)

:star::star::star::star: